### PR TITLE
NZP-3111 Update NZ Payroll Employee/Employment/LeaveSetup/LeaveType doco #1

### DIFF
--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -78,7 +78,9 @@ paths:
                               "payrollCalendarID": "9aa56064-990f-4ad3-a189-d966d8f6a030",
                               "updatedDateUTC": "2019-09-24T05:08:45",
                               "createdDateUTC": "2019-09-22T23:58:23",
-                              "endDate": null
+                              "endDate": null,
+                              "engagementType": "FixedTerm",
+                              "fixedTermEndDate": "2026-01-01T00:00:00"
                             },
                             {
                               "employeeID": "1c4f0c92-03ad-43f2-a690-ee51397ece6a",
@@ -100,7 +102,9 @@ paths:
                               "payrollCalendarID": "9aa56064-990f-4ad3-a189-d966d8f6a030",
                               "updatedDateUTC": "2019-09-23T00:16:25",
                               "createdDateUTC": "2019-09-23T00:12:16",
-                              "endDate": null
+                              "endDate": null,
+                              "engagementType": "Permanent",
+                              "fixedTermEndDate": null 
                             }
                           ]
                         }'
@@ -236,7 +240,9 @@ paths:
                           "payrollCalendarID": null,
                           "updatedDateUTC": "2020-08-24T20:27:22",
                           "createdDateUTC": "2020-08-24T20:27:22",
-                          "endDate": null
+                          "endDate": null,
+                          "engagementType": null,
+                          "fixedTermEndDate": null                     
                         }
                       }'
         '400':
@@ -320,7 +326,9 @@ paths:
                             "payrollCalendarID": "9aa56064-990f-4ad3-a189-d966d8f6a030",
                             "updatedDateUTC": "2019-09-24T05:08:45",
                             "createdDateUTC": "2019-09-22T23:58:23",
-                            "endDate": null
+                            "endDate": null,
+                            "engagementType": "FixedTerm",
+                            "fixedTermEndDate": "2026-01-01T00:00:00"
                           }
                         }'
     put:
@@ -458,7 +466,9 @@ paths:
                             "payrollCalendarID": "9aa56064-990f-4ad3-a189-d966d8f6a030",
                             "updatedDateUTC": "2020-08-24T20:29:43",
                             "createdDateUTC": "2019-09-22T23:58:23",
-                            "endDate": null
+                            "endDate": null,
+                            "engagementType": null
+                            "fixedTermEndDate": null
                           }
                         }'
         '400':
@@ -534,6 +544,19 @@ paths:
           python: start_date
           ruby: start_date
           object: employment
+        - engagementType:
+          is_variable: true
+          key: engagementType
+          keyPascal: EngagementType
+          keySnake: engagement_type
+          object: employment
+        - fixedTermEndDate:
+          is_variable: true
+          nonString: true
+          key: fixedTermEndDate
+          keyPascal: FixedTermEndDate
+          keySnake: fixed_term_end_date
+          object: employment
           is_last: true 
       summary: Creates an employment detail for a specific employee
       parameters:
@@ -563,7 +586,9 @@ paths:
                           "problem": null,
                           "employment": {
                             "payrollCalendarID": "9aa56064-990f-4ad3-a189-d966d8f6a030",
-                            "startDate": "2020-09-02T00:00:00"
+                            "startDate": "2020-09-02T00:00:00",
+                            "engagementType": "FixedTerm",
+                            "fixedTermEndDate": "2026-01-01T00:00:00"
                           }
                         }'
         '400':
@@ -580,7 +605,9 @@ paths:
               $ref: '#/components/schemas/Employment'
             example: '{
                         "payrollCalendarID": "9aa56064-990f-4ad3-a189-d966d8f6a030",
-                        "startDate": "2020-09-02"
+                        "startDate": "2020-09-02",
+                        "engagementType": "FixedTerm",
+                        "fixedTermEndDate": "2026-01-01"
                       }'
   /Employees/{EmployeeID}/Tax:
     parameters:
@@ -1544,7 +1571,20 @@ paths:
           nonString: true
           default: 10.50
           object: employeeLeaveSetup
-          is_last: true
+        - sickLeaveScheduleOfAccrual:
+          is_variable: true
+          key: sickLeaveScheduleOfAccrual
+          keyPascal: SickLeaveScheduleOfAccrual
+          keySnake: sick_leave_schedule_of_accrual
+          object: employeeLeaveSetup
+        - sickLeaveAnniversaryDate:
+          is_variable: true
+          nonString: true
+          key: sickLeaveAnniversaryDate
+          keyPascal: SickLeaveAnniversaryDate
+          keySnake: sick_leave_anniversary_date
+          object: employeeLeaveSetup
+          is_last: true 
       summary: Creates a leave set-up for a specific employee. This is required before viewing, configuring and requesting leave for an employee
       parameters:
         - $ref: '#/components/parameters/idempotencyKey'
@@ -1578,7 +1618,9 @@ paths:
                             "negativeAnnualLeaveBalancePaidAmount": null,
                             "sickLeaveHoursToAccrueAnnually": 20,
                             "sickLeaveMaximumHoursToAccrue": null,
-                            "sickLeaveOpeningBalance": 10
+                            "sickLeaveOpeningBalance": 10,
+                            "sickLeaveScheduleOfAccrual": "OnAnniversaryDate",
+                            "sickLeaveAnniversaryDate": "2023-12-31"
                           }
                         }'
         '400':
@@ -1597,7 +1639,9 @@ paths:
                         "holidayPayOpeningBalance": 10,
                         "annualLeaveOpeningBalance": 100,
                         "sickLeaveHoursToAccrueAnnually": 20,
-                        "sickLeaveOpeningBalance": 10
+                        "sickLeaveOpeningBalance": 10,
+                        "sickLeaveScheduleOfAccrual": "OnAnniversaryDate",
+                        "sickLeaveAnniversaryDate": "2023-12-31"
                       }'
   /Employees/{EmployeeID}/LeaveTypes:
     parameters:
@@ -1645,7 +1689,7 @@ paths:
                               "percentageOfGrossEarnings": 8,
                               "includeHolidayPayEveryPay": true,
                               "showAnnualLeaveInAdvance": null,
-                              "annualLeaveTotalAmountPaid": null
+                              "annualLeaveTotalAmountPaid": null,            "scheduleOfAccrualDate": null
                             }
                           ]
                         }'
@@ -1697,7 +1741,13 @@ paths:
           nonString: true 
           default: 5.25
           object: employeeLeaveType
-          is_last: true
+        - scheduleOfAccrualDate:
+          is_variable: true
+          nonString: true
+          key: scheduleOfAccrualDate
+          keyPascal: ScheduleOfAccrualDate
+          keySnake: schedule_of_accrual_date
+          object: employeeLeaveType
       parameters:
         - $ref: '#/components/parameters/idempotencyKey'
         - name: EmployeeID
@@ -1733,7 +1783,8 @@ paths:
                             "percentageOfGrossEarnings": 0,
                             "includeHolidayPayEveryPay": null,
                             "showAnnualLeaveInAdvance": null,
-                            "annualLeaveTotalAmountPaid": null
+                            "annualLeaveTotalAmountPaid": null,
+                            "scheduleOfAccrualDate": null
                           }
                         }'
         '400':
@@ -6405,6 +6456,16 @@ components:
           type: string
           format: date-time
           x-is-datetime: true
+        engagementType:
+          description: Engagement type of the employee
+          type: string
+          example: Permanent
+        fixedTermEndDate:
+          description: End date for an employee with a fixed-term engagement type
+          type: string
+          format: date
+          example: 2020-01-19
+          x-is-date: true
     EmploymentObject:
       type: object
       properties:
@@ -6433,6 +6494,16 @@ components:
           type: string
           format: date
           x-is-date: true 
+        engagementType:
+          description: Engagement type of the employee
+          type: string
+          example: Permanent
+        fixedTermEndDate:
+          description: End date for an employee with a fixed-term engagement type
+          type: string
+          format: date
+          example: 2020-01-19
+          x-is-date: true
     EmployeeTaxObject:
       type: object
       properties:
@@ -6968,6 +7039,16 @@ components:
           format: double
           x-is-money: true
           example: 10.5
+        SickLeaveScheduleOfAccrual:
+          description: Set Schedule of Accrual Type for Sick Leave
+          type: string
+          example: OnAnniversaryDate
+        SickLeaveAnniversaryDate:
+          description: If Sick Leave Schedule of Accrual is "OnAnniversaryDate", this is the date when entitled to Sick Leave
+          type: string
+          format: date
+          example: 2020-01-19
+          x-is-date: true
     EmployeeLeaveTypeObject:
       type: object
       properties:
@@ -7028,6 +7109,12 @@ components:
           type: number
           format: double
           x-is-money: true
+        scheduleOfAccrualDate:
+          description: The date when an employee becomes entitled to their accrual.
+          type: string
+          format: date
+          example: 2020-01-19
+          x-is-date: true
     EmployeePayTemplateObject:
       type: object
       properties:

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -79,8 +79,8 @@ paths:
                               "updatedDateUTC": "2019-09-24T05:08:45",
                               "createdDateUTC": "2019-09-22T23:58:23",
                               "endDate": null,
-                              "engagementType": "FixedTerm",
-                              "fixedTermEndDate": "2026-01-01T00:00:00"
+                              "engagementType": "Casual",
+                              "fixedTermEndDate": null
                             },
                             {
                               "employeeID": "1c4f0c92-03ad-43f2-a690-ee51397ece6a",
@@ -103,7 +103,7 @@ paths:
                               "updatedDateUTC": "2019-09-23T00:16:25",
                               "createdDateUTC": "2019-09-23T00:12:16",
                               "endDate": null,
-                              "engagementType": "Permanent",
+                              "engagementType": null,
                               "fixedTermEndDate": null 
                             }
                           ]
@@ -819,7 +819,7 @@ paths:
             schema:
               $ref: '#/components/schemas/EmployeeTax'
             example: ''
-  /Employees/{EmployeeID}/openingBalances:
+  /Employees/{EmployeeID}/OpeningBalances:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get: 
@@ -1508,7 +1508,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Problem'
-  /Employees/{EmployeeID}/leaveSetup:
+  /Employees/{EmployeeID}/LeaveSetup:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     post:
@@ -1689,7 +1689,8 @@ paths:
                               "percentageOfGrossEarnings": 8,
                               "includeHolidayPayEveryPay": true,
                               "showAnnualLeaveInAdvance": null,
-                              "annualLeaveTotalAmountPaid": null,            "scheduleOfAccrualDate": null
+                              "annualLeaveTotalAmountPaid": null,            
+                              "scheduleOfAccrualDate": null
                             }
                           ]
                         }'
@@ -1748,6 +1749,7 @@ paths:
           keyPascal: ScheduleOfAccrualDate
           keySnake: schedule_of_accrual_date
           object: employeeLeaveType
+          is_last: true 
       parameters:
         - $ref: '#/components/parameters/idempotencyKey'
         - name: EmployeeID
@@ -2021,7 +2023,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Problem'
-  /Employees/{EmployeeID}/PayTemplates/earnings:
+  /Employees/{EmployeeID}/PayTemplates/Earnings:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     post:
@@ -2152,7 +2154,7 @@ paths:
                         "earningsRateID": "f9d8f5b5-9049-47f4-8541-35e200f750a5",
                         "name": "My New One"
                       }'
-  /Employees/{EmployeeID}/PayTemplates/earnings/{PayTemplateEarningID}:
+  /Employees/{EmployeeID}/PayTemplates/Earnings/{PayTemplateEarningID}:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     put:
@@ -2332,7 +2334,7 @@ paths:
                           "pagination": null,
                           "problem": null
                         }'
-  /Employees/{EmployeeID}/paytemplateearnings:
+  /Employees/{EmployeeID}/Paytemplateearnings:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     post:
@@ -6480,6 +6482,7 @@ components:
       required:
         - PayrollCalendarID
         - StartDate
+        - EngagementType
       properties:
         payrollCalendarID:
           description: Xero unique identifier for the payroll calendar of the employee


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The following changes have need made to the Payroll API which is reflected in the spec changes in this PR.
- Add **EngagementType** and **FixedTermEndDate** FIELDS to the Payroll NZ - Employee  Endpoint.
- Add the **EngagementType** and **FixedTermEndDate** FIELDS to the Payroll NZ -  Employment  Endpoint.
- Add the **SickLeaveScheduleOfAccrual** and **SickLeaveAnniversaryDate** FIELDS to the Payroll NZ - Employee Leave 
- Add the **ScheduleOfAccrualDate** FIELD to the Payroll NZ - Employee Leave Types Endpoint.

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
The changes being made are part of an initiative to help support our NZ customers with Holiday Act compliance. 
We are adding new functionality to allow API consumers to specify an employees engagement type (ak. Permanent, Fixed-term or Casual).
In addition we have also added new functionality to enable API consumers to set custom accrual dates for Sick Leave for entitled employees.

<!--- If it fixes an open issue, please link to the issue here. -->


## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
